### PR TITLE
Force SHELL env for muon worker being seen as node

### DIFF
--- a/anonize2-jumbo.js
+++ b/anonize2-jumbo.js
@@ -1,4 +1,7 @@
-var Module;
+var Module = {
+  ENVIRONMENT : 'SHELL'
+}
+
 if (!Module) Module = (typeof Module !== "undefined" ? Module : null) || {};
 var moduleOverrides = {};
 for (var key in Module) {


### PR DESCRIPTION
Workers don't have node access but do have process.type detection
so this file was detecting the env wrong.